### PR TITLE
Mobile and ~960px padding tweaks

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -24,7 +24,7 @@ const Col = styled.div`
     display: ${props => (props.middle ? "none" : "block")};
     margin-top: 0;
     margin: 0 auto;
-    padding: ${props => (props.right ? "30px 0" : "30px")};
+    padding: 30px 0;
   }
 `;
 

--- a/src/App.js
+++ b/src/App.js
@@ -6,27 +6,25 @@ import Loading from "./components/loading";
 import styled from "styled-components";
 
 const Row = styled.div`
-  display: flex;
-  flex-flow: row wrap;
-  width: 1020px;
+  display: grid;
+  max-width: 1060px;
   margin: 0 auto;
-  align-content: space-between;
+  padding: 0 20px;
+  grid-template-columns: auto 1fr 210px 375px;
 
   @media all and (max-width: 960px) {
     width: 100%;
+    display: block;
   }
 `;
 const Col = styled.div`
-  flex: 1;
-
   margin-top: ${props => (props.right ? 70 : 0)};
 
   @media all and (max-width: 960px) {
-    flex: ${props => (props.middle ? "1" : "2 100%")};
     display: ${props => (props.middle ? "none" : "block")};
     margin-top: 0;
     margin: 0 auto;
-    padding: 30px;
+    padding: 30px 10px;
   }
 `;
 

--- a/src/components/facebook-mobile-post/FacebookMobilePost.js
+++ b/src/components/facebook-mobile-post/FacebookMobilePost.js
@@ -8,8 +8,9 @@ import comment from "../../icons/comment.svg";
 import share from "../../icons/share.svg";
 
 const Container = styled.div`
-  width: 375px;
+  max-width: 375px;
   display: block;
+  width: 100%;
   box-shadow: 0px 9px 12px rgba(0, 0, 0, 0.06);
   background: #fff;
 `;

--- a/src/components/form/Form.js
+++ b/src/components/form/Form.js
@@ -3,7 +3,7 @@ import styled from "styled-components";
 
 const Container = styled.div`
   box-shadow: 0px 9px 12px rgba(0, 0, 0, 0.06);
-  width: 435px;
+  max-width: 435px;
   border-radius: 3px;
   background: #fff;
 `;

--- a/src/components/form/Form.js
+++ b/src/components/form/Form.js
@@ -3,7 +3,6 @@ import styled from "styled-components";
 
 const Container = styled.div`
   box-shadow: 0px 9px 12px rgba(0, 0, 0, 0.06);
-  max-width: 435px;
   border-radius: 3px;
   background: #fff;
 

--- a/src/components/preview/Preview.js
+++ b/src/components/preview/Preview.js
@@ -2,7 +2,7 @@ import React from "react";
 import styled from "styled-components";
 
 const Container = styled.div`
-  width: 375px;
+  max-width: 375px;
   border-top: 0.5px solid #dedede;
 `;
 

--- a/src/components/warnings/Warnings.js
+++ b/src/components/warnings/Warnings.js
@@ -5,7 +5,9 @@ import sad from "../../icons/sad.svg";
 const Container = styled.div`
   font-family: "Roboto";
   -webkit-font-smoothing: antialiased;
-  width: 375px;
+  max-width: 375px;
+  width: 100%;
+  padding-right: 10px;
 `;
 const WarningTitle = styled.div`
   font-family: Roboto;

--- a/src/components/warnings/Warnings.js
+++ b/src/components/warnings/Warnings.js
@@ -7,7 +7,6 @@ const Container = styled.div`
   -webkit-font-smoothing: antialiased;
   max-width: 375px;
   width: 100%;
-  padding-right: 10px;
 `;
 const WarningTitle = styled.div`
   font-family: Roboto;


### PR DESCRIPTION
Hey! Love this tool! Just made a couple of padding tweaks for 960-1100px screens to stop it hitting the edge of the viewport. Switched to CSS grid to tidy up the `App.js` layout styling. And finally, swapped the fixed widths to `max-width` to stop the form/preview spilling over on smaller mobile screens.